### PR TITLE
fix: long-running table lock if there is a migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ A class of constants to indicate to the `ingest` function how it should use any 
 
 `Visibility`
 
-A class of constants to indicate when changes are visible to other database clients. Note that schema changes become visible even if there are no batches.
+A class of constants to indicate when data changes are visible to other database clients. Schema changes become visible before the first batch.
 
-- `AFTER_EACH_BATCH` - changes are visible to other database clients after each batch. This is the string `__AFTER_EACH_BATCH__`.
+- `AFTER_EACH_BATCH` - data changes are visible to other database clients after each batch. This is the string `__AFTER_EACH_BATCH__`.
 
 ---
 


### PR DESCRIPTION
Suspect that adding a column holds an access exclusive lock on the table, even though it doesn't re-write the entire table. So, to avoid ingest holding this lock during a batch, the migrations have to be committed, and so have to then be visible before the first batch.

Other visibility behaviour is possible - for example always ingesting into a migration table and swapping with the live at the end. But this would require a copy of all data in all migration circumstances.