### PR TITLE
feat: when de-duplicating choose the most recent row

### DIFF
--- a/pg_bulk_ingest.py
+++ b/pg_bulk_ingest.py
@@ -383,7 +383,7 @@ def ingest(
             logger.info('Check and remove any duplicates in the batch table')
             dedup_query = sql.SQL('''
                 DELETE FROM {schema}.{batch_table} a USING (
-                    SELECT MIN(ctid) as ctid, {pk_columns}
+                    SELECT MAX(ctid) as ctid, {pk_columns}
                     FROM {schema}.{batch_table}
                     GROUP BY {pk_columns} HAVING COUNT(*) > 1
                 ) b

--- a/test_pg_bulk_ingest.py
+++ b/test_pg_bulk_ingest.py
@@ -358,7 +358,7 @@ def test_upsert_with_duplicates_in_batch():
             (
                 (my_table, (1, 2, 'a', 'b')),
                 (my_table, (3, 4, 'c', 'd')),
-                (my_table, (1, 2, 'a', 'b')),
+                (my_table, (1, 2, 'a', 'c')),
             ),
         ),
     )
@@ -386,7 +386,7 @@ def test_upsert_with_duplicates_in_batch():
     oid_2 = _get_table_oid(engine, my_table)
 
     assert results == [
-        (1, 2, 'a', 'b'),
+        (1, 2, 'a', 'c'),
         (3, 4, 'e', 'f'),
         (3, 6, 'g', 'h'),
     ]


### PR DESCRIPTION
This is to make it consistent with the regular upsert-behaviour - most recent row wins.