### PR TITLE
feat: delete before first batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ A class of constants that controls how existing data in the table is deleted
 
    There is no deleting of existing data. This is the string `__OFF__`.
 
-- `ALL`
+- `BEFORE_FIRST_BATCH`
 
-   All existing data in the table is deleted. This is the string `__ALL__`.
+   All existing data in the table is deleted just before the first batch is ingested. If there are no batches, no data is deleted. This is the string `__BEFORE_FIRST_BATCH__`.
 
 
 ---

--- a/test_pg_bulk_ingest.py
+++ b/test_pg_bulk_ingest.py
@@ -1108,7 +1108,17 @@ def test_delete():
         ),
     )
     with engine.connect() as conn:
-        ingest(conn, metadata, batches_2, delete=Delete.ALL)
+        ingest(conn, metadata, batches_2, delete=Delete.BEFORE_FIRST_BATCH)
+
+    with engine.connect() as conn:
+        results = conn.execute(sa.select(my_table).order_by('integer')).fetchall()
+
+    assert results == [
+        (2,),
+    ]
+
+    with engine.connect() as conn:
+        ingest(conn, metadata, lambda _: (), delete=Delete.BEFORE_FIRST_BATCH)
 
     with engine.connect() as conn:
         results = conn.execute(sa.select(my_table).order_by('integer')).fetchall()


### PR DESCRIPTION
This converts the Delete.ALL to Delete.BEFORE_FIRST_BATCH. In the case of there being batches ingested, the behaviour is identical. In the case of there being no batches, no data is deleted. This is helpful for the cases where each batch contains the entire dataset but if no batches after high watermark, we want to leave the data alone.