### PR TITLE
fix: only create a table to ingest into if there is at least one batch

### DIFF
--- a/pg_bulk_ingest.py
+++ b/pg_bulk_ingest.py
@@ -287,11 +287,12 @@ def ingest(
 
     live_table = sa.Table(target_table.name, sa.MetaData(), schema=target_table.schema, autoload_with=conn)
 
-    ingest_table = create_first_batch_ingest_table_if_necessary(sql, conn, live_table, target_table)
 
-    for high_watermark_value, batch_metadata, batch in batches(high_watermark_value):
+    for i, (high_watermark_value, batch_metadata, batch) in enumerate(batches(high_watermark_value)):
+        if i == 0:
+            ingest_table = create_first_batch_ingest_table_if_necessary(sql, conn, live_table, target_table)
 
-        if ingest_table is not target_table and delete == Delete.OFF:
+        if i == 0 and ingest_table is not target_table and delete == Delete.OFF:
             target_table_column_names = tuple(col.name for col in target_table.columns)
             columns_to_select = tuple(col for col in live_table.columns.values() if col.name in target_table_column_names)
             conn.execute(sa.insert(ingest_table).from_select(


### PR DESCRIPTION
In the case of no batches, which can happen if there is logic based on high watermark to not ingest, then an empty table was being created and committed, and so forever visible to other database users.

This change makes it so the table is only created if there is a batch.