### PR TITLE
ci: use latest checkout action to avoid errors

### DIFF
--- a/.github/workflows/deploy-package-to-pypi.yml
+++ b/.github/workflows/deploy-package-to-pypi.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           - ci-psycopg3-sqlalchemy2
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
       - uses: "actions/setup-python@v4"
         with:
           python-version: '${{ matrix.python-version }}'


### PR DESCRIPTION
This avoids errors like

Error: Can't use 'tar -xzf' extract archive file:
/home/runner/work/_actions/_temp_575ca616-4abd-4ab1-8b7a-7cfa8cba3133/3728ca6e-c608-40ab-85d1-432455aec994.tar.gz. return code: 2.