### PR TITLE
refactor: comment out dead code (but don't remove it)

### DIFF
--- a/pg_bulk_ingest.py
+++ b/pg_bulk_ingest.py
@@ -217,8 +217,11 @@ def ingest(
                     yield chunk[offset - to_yield : offset]
 
             class FileLikeObj(IOBase):
-                def readable(self):
-                    return True
+                # psycopg doesn't use the "readable" function, but keeping this here and
+                # commented out in case this code is copy and pasted elsewhere. Some code
+                # that expects file-like objects need it
+                # def readable(self):
+                #    return True
 
                 def read(self, size=-1):
                     return base().join(


### PR DESCRIPTION
Commenting it out as a form of documentation to explain why it's not needed, as well to avoid a gotcha in case someone decided to copy and paste the to_file_like_obj code elsewhere