### PR TITLE
refactor: use to-file-like-obj

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 dependencies = [
     "sqlalchemy>=1.4.24",
     "pg-force-execute>=0.0.10",
+    "to-file-like-obj>=0.0.5",
 ]
 
 [project.optional-dependencies]
@@ -35,14 +36,17 @@ ci = [
 ci-psycopg2-sqlalchemy1 = [
     "psycopg2==2.9.2",
     "sqlalchemy==1.4.24",
+    "to-file-like-obj==0.0.5",
 ]
 ci-psycopg2-sqlalchemy2 = [
     "psycopg2==2.9.2",
     "sqlalchemy==2.0.0",
+    "to-file-like-obj==0.0.5",
 ]
 ci-psycopg3-sqlalchemy2 = [
     "psycopg==3.1.4",
     "sqlalchemy==2.0.0",
+    "to-file-like-obj==0.0.5",
 ]
 
 [project.urls]


### PR DESCRIPTION
This now uses the code in https://github.com/uktrade/to-file-like-obj rather than having a copy of it.

This is to reduce overal duplication of code in many uses of pg-bulk-ingest, because https://github.com/uktrade/to-file-like-obj will be used anywhere (because for example it's used in the robust stream-parsing of CSVs)