### PR TITLE
feat: support multiple tables

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -9,13 +9,13 @@ The API is a single function `ingest`, together with classes of string constants
 
 ---
 
-`ingest`(conn, metadata, batches, on_before_visible=lambda conn, latest_batch_metadata: None, high_watermark=HighWatermark.LATEST, visibility=Visibility.AFTER_EACH_BATCH, upsert=Upsert.IF_PRIMARY_KEY, delete=Delete.OFF)
+`ingest`(conn, metadata, batches, on_before_visible=lambda conn, latest_batch_metadata: None, high_watermark=HighWatermark.LATEST, visibility=Visibility.AFTER_EACH_BATCH, upsert=Upsert.IF_PRIMARY_KEY, delete=Delete.OFF, max_rows_per_table_buffer=10000)
 
 Ingests data into a table
 
 - `conn` - A [SQLAlchemy connection](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection) not in a transaction, i.e. started by `connection` rather than `begin`.
 
-- `metadata` - A SQLAlchemy metadata of a single table.
+- `metadata` - A SQLAlchemy metadata of one or more tables.
 
 - `batches` - A function that takes a high watermark, returning an iterable that yields data batches that are strictly after this high watermark. See Usage above for an example.
 
@@ -34,6 +34,8 @@ Ingests data into a table
 - `upsert` (optional) - A member of the `Upsert` class, controlling whether an upsert is performed when ingesting data
 
 - `delete` (optional) - A member of the `Delete` class, controlling if existing rows are to be deleted.
+
+- `max_rows_per_table_buffer` (optional) - An integer number of rows to buffer in memory per table when ingesting into multiple tables.
 
 ---
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -52,7 +52,7 @@ from pg_bulk_ingest import HighWatermark, Visibility, Upsert, Delete, ingest
 # if using a PostgreSQL instance elsewhere or setup differently
 engine = sa.create_engine('postgresql+psycopg://postgres@127.0.0.1:5432/')
 
-# A SQLAlchemy Metadata of a single table definition
+# A SQLAlchemy Metadata
 metadata = sa.MetaData()
 my_table = sa.Table(
     "my_table",

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 homepage: true
 layout: product
 title: Ingest large amounts of data into PostgreSQL
-description: Use this Python package to ingest data into a SQLAlchemy-defined PostgreSQL table, leveraging high-watermarking to keep it up to date without re-ingesting the same data.
+description: Use this Python package to ingest data into SQLAlchemy-defined PostgreSQL tables, leveraging high-watermarking to keep them up to date without re-ingesting the same data.
 startButton:
   href: "get-started"
   text: Get started

--- a/docs/under-the-hood.md
+++ b/docs/under-the-hood.md
@@ -10,6 +10,8 @@ It's an aim of pg-bulk-ingest for clients to not have to worry about internals. 
 
 - Ingestion is transactional - each batch is ingested completely or not at all
 
+- If there are multiple tables to be ingested into, then data can be buffered in memory, up to a default maximum of 10000 rows per table. To avoid this either `COPY FROM` would have to not be used, which is undesirable for performance reasons, or multiple connections to the database would have to be used, which would not support a single transaction per batch.
+
 - If the table has a primary key and `upsert=IF_PRIMARY_KEY` then an "upsert" is performed. Data is ingested into an intermediate table, and an `INSERT ... ON CONFLICT(...) DO UPDATE` is performed to copy rows from this intermediate table to the existing table. This doesn't involve an ACCESS EXCLUSIVE lock on the live table, so SELECTs can continue in parallel.
 
 - Migrations usually require a long running ACCESS EXCLUSIVE lock on the live table that prevent concurrent SELECTs from progressing. To avoid this, `ingest` creates an intermediate table that matches the required definition, it copies all existing data into this table (unless `delete=Delete.OFF`), and it replaces the live table at the end of the first batch. This replacement requires an ACCESS EXCLUSIVE lock, but only for a short time. Backends that hold locks that block migrations are forcably terminated after a delay using [pg-force-execute](https://github.com/uktrade/pg-force-execute).

--- a/pg_bulk_ingest.py
+++ b/pg_bulk_ingest.py
@@ -268,7 +268,7 @@ def ingest(
 
     for high_watermark_value, batch_metadata, batch in batches(high_watermark_value):
 
-        batch_ingest_tables = set()
+        batch_ingest_tables = {}
 
         if target_table not in ingested_target_tables:
             ingest_table = create_first_batch_ingest_table_if_necessary(sql, conn, live_table, target_table)
@@ -282,7 +282,7 @@ def ingest(
                 ))
             ingested_target_tables.add(target_table)
 
-        batch_ingest_tables.add(ingest_table)
+        batch_ingest_tables[target_table] = ingest_table
 
         logger.info('Ingesting batch %s with high watermark value %s', batch_metadata, high_watermark_value)
 
@@ -377,7 +377,7 @@ def ingest(
                     .as_string(conn.connection.driver_connection))
                 )
 
-        for ingest_table in batch_ingest_tables:
+        for ingest_table in batch_ingest_tables.values():
             logger.info('Calling on_before_visible callback')
             on_before_visible(conn, ingest_table, batch_metadata)
             logger.info('Calling of on_before_visible callback complete')

--- a/pg_bulk_ingest.py
+++ b/pg_bulk_ingest.py
@@ -153,6 +153,9 @@ def ingest(
 
         return ingest_table
 
+    def split_batch_into_tables(target_table, live_table, batch):
+        yield (target_table, live_table, batch)
+
     def csv_copy(sql, copy_from_stdin, conn, user_facing_table, batch_table, rows):
 
         def get_converter(sa_type):
@@ -264,7 +267,7 @@ def ingest(
 
         batch_ingest_tables = {}
 
-        for target_table, live_table, table_batch in ((target_tables[0], live_tables[0], batch),):
+        for target_table, live_table, table_batch in split_batch_into_tables(target_tables[0], live_tables[0], batch):
 
             if target_table in batch_ingest_tables:
                 # Always ingest into the same table for a batch

--- a/pg_bulk_ingest.py
+++ b/pg_bulk_ingest.py
@@ -233,6 +233,7 @@ def ingest(
         logger.info('Target table %s created or already existed', target_table)
 
     target_table = next(iter(metadata.tables.values()))
+    live_table = sa.Table(target_table.name, sa.MetaData(), schema=target_table.schema, autoload_with=conn)
 
     logger.info('Finding high-watermark of %s', str(target_table.name))
     comment = conn.execute(sa.text(sql.SQL('''
@@ -253,8 +254,6 @@ def ingest(
     else:
         high_watermark_value = high_watermark
     logger.info('High-watermark of %s.%s is %s', str(target_table.schema), str(target_table.name), high_watermark_value)
-
-    live_table = sa.Table(target_table.name, sa.MetaData(), schema=target_table.schema, autoload_with=conn)
 
     for i, (high_watermark_value, batch_metadata, batch) in enumerate(batches(high_watermark_value)):
         if i == 0:

--- a/pg_bulk_ingest.py
+++ b/pg_bulk_ingest.py
@@ -264,13 +264,13 @@ def ingest(
         if i == 0:
             ingest_table = create_first_batch_ingest_table_if_necessary(sql, conn, live_table, target_table)
 
-        if i == 0 and ingest_table is not target_table and delete == Delete.OFF:
-            target_table_column_names = tuple(col.name for col in target_table.columns)
-            columns_to_select = tuple(col for col in live_table.columns.values() if col.name in target_table_column_names)
-            conn.execute(sa.insert(ingest_table).from_select(
-                tuple(col.name for col in columns_to_select),
-                sa.select(*columns_to_select),
-            ))
+            if ingest_table is not target_table and delete == Delete.OFF:
+                target_table_column_names = tuple(col.name for col in target_table.columns)
+                columns_to_select = tuple(col for col in live_table.columns.values() if col.name in target_table_column_names)
+                conn.execute(sa.insert(ingest_table).from_select(
+                    tuple(col.name for col in columns_to_select),
+                    sa.select(*columns_to_select),
+                ))
 
         logger.info('Ingesting batch %s with high watermark value %s', batch_metadata, high_watermark_value)
 

--- a/pg_bulk_ingest.py
+++ b/pg_bulk_ingest.py
@@ -233,7 +233,6 @@ def ingest(
         logger.info('Target table %s created or already existed', target_table)
 
     target_table = next(iter(metadata.tables.values()))
-    is_upsert = upsert == Upsert.IF_PRIMARY_KEY and any(column.primary_key for column in target_table.columns.values())
 
     logger.info('Finding high-watermark of %s', str(target_table.name))
     comment = conn.execute(sa.text(sql.SQL('''
@@ -272,6 +271,7 @@ def ingest(
 
         logger.info('Ingesting batch %s with high watermark value %s', batch_metadata, high_watermark_value)
 
+        is_upsert = upsert == Upsert.IF_PRIMARY_KEY and any(column.primary_key for column in target_table.columns.values())
         if not is_upsert:
             logger.info('Ingesting without upsert')
             csv_copy(sql, copy_from_stdin, conn, target_table, ingest_table, batch)

--- a/pg_bulk_ingest.py
+++ b/pg_bulk_ingest.py
@@ -256,7 +256,6 @@ def ingest(
 
     live_table = sa.Table(target_table.name, sa.MetaData(), schema=target_table.schema, autoload_with=conn)
 
-
     for i, (high_watermark_value, batch_metadata, batch) in enumerate(batches(high_watermark_value)):
         if i == 0:
             ingest_table = create_first_batch_ingest_table_if_necessary(sql, conn, live_table, target_table)

--- a/pg_bulk_ingest.py
+++ b/pg_bulk_ingest.py
@@ -297,7 +297,7 @@ def ingest(
             is_upsert = upsert == Upsert.IF_PRIMARY_KEY and any(column.primary_key for column in target_table.columns.values())
             if not is_upsert:
                 logger.info('Ingesting without upsert')
-                csv_copy(sql, copy_from_stdin, conn, target_table, ingest_table, batch)
+                csv_copy(sql, copy_from_stdin, conn, target_table, ingest_table, table_batch)
             else:
                 logger.info('Ingesting with upsert')
                 # Create a batch table, and ingest into it
@@ -313,7 +313,7 @@ def ingest(
                     schema=ingest_table.schema
                 )
                 batch_db_metadata.create_all(conn)
-                csv_copy(sql, copy_from_stdin, conn, target_table, batch_table, batch)
+                csv_copy(sql, copy_from_stdin, conn, target_table, batch_table, table_batch)
                 logger.info('Ingestion into batch table complete')
 
                 # check and remove any duplicates in the batch


### PR DESCRIPTION
This adds support for ingesting to multiple tables in a single call to the ingest function.

This works by having buffering incoming data, up to a maximum of 10k rows per table. But it does it in a slightly fancy way, where

- The data is still streamed in for the first table using COPY FROM - it doesn't wait for a buffer to be filled.
- But during this, rows that appear in the stream for other tables are buffered.
- If a buffer hits 10k rows then the first COPY FROM is ended, and a new one begun, starting off with an empty of its 10k buffer, but then continues in a streaming way. And this one continues until the next table fills its buffer, and so on.

This means that the behaviour for a single table is exactly as now: no buffer is used because it's all streamed straight in in a single COPY FROM. And the stickiness also means that the number of separate COPY FROMs should be minimised, no matter the order that the table/rows appear in the source stream.

Other alternatives were considered:

- Using separate connections. This would reduce memory use and be more streaming, but we would lose the transaction-ness of a single batch. This _is_ PostgreSQL after all, let's leverage what it gives us.
- Not using COPY FROM, but say separate INSERT statements. Would avoid buffering, but each INSERT would be slower.