### PR TITLE
test: assert that the correct table exists if no batches

### DIFF
--- a/test_pg_bulk_ingest.py
+++ b/test_pg_bulk_ingest.py
@@ -220,9 +220,14 @@ def test_if_no_batches_then_only_target_table_visible():
         ingest(conn, metadata, batches, delete=Delete.BEFORE_FIRST_BATCH)
 
     with engine.connect() as conn:
+        number_of_rows = len(conn.execute(sa.select(my_table)).fetchall())
+
         last_check = conn.execute(sa.text('''
             SELECT count(*) FROM pg_class;
         ''')).fetchall()[0][0]
+
+    # The table must exist to have gotten this
+    assert number_of_rows == 0
 
     # we expect the target table to be visible but no others
     assert last_check == first_check + 1


### PR DESCRIPTION
This adds an assertion that in the case of no batches, then the correct table does get created (and with no rows).

This is to be more sure on what happens when there are no batches.