### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+* @uktrade/data-infrastructure
+


### PR DESCRIPTION
This is so lots of people in uktrade can have write access, but we can still enforce reviews from a single team before merge