### PR TITLE
docs: use correct URI format for dataset-aware scheduling

### DIFF
--- a/docs/airflow.md
+++ b/docs/airflow.md
@@ -169,7 +169,7 @@ def create_dag(dag_id, schema, table_name):
     def Pipeline():
         sync.override(
             outlets=[
-                Dataset(f'postgresql://datasets/{schema}.{table_name}'),
+                Dataset(f'postgresql://datasets//{schema}/{table_name}'),
             ]
         )(
             dag_id=dag_id,


### PR DESCRIPTION
The URI for postgresql:// datasets now seems to have a stricter format:

postgresql://host/database/schema/table

But it does allow the database to be empty, so going for that to keep it shorter, and still applicable to most cases that run a single database on the host.