### PR TITLE
fix: save_comment method to use passed table variables

### DIFF
--- a/pg_bulk_ingest.py
+++ b/pg_bulk_ingest.py
@@ -82,8 +82,8 @@ def ingest(
         conn.execute(sa.text(sql.SQL('''
              COMMENT ON TABLE {schema}.{table} IS {comment}
         ''').format(
-            schema=sql.Identifier(target_table.schema),
-            table=sql.Identifier(target_table.name),
+            schema=sql.Identifier(schema),
+            table=sql.Identifier(table),
             comment=sql.Literal(comment),
         ).as_string(conn.connection.driver_connection)))
 


### PR DESCRIPTION
Issue identified when a single batch of data is ingested to multiple SQL tables, the high watermark is not written to the correct table (the first in the list of target tables) in order to be used in subsequent DAG runs. This is amended by using the schema and table variables as defined in the save_comment method. A test for this (test_multiple_tables_high_watermark) can be found in the test script.