### PR TITLE
feat: make pg-bulk-ingest views compatible

### DIFF
--- a/pg_bulk_ingest/__init__.py
+++ b/pg_bulk_ingest/__init__.py
@@ -553,9 +553,8 @@ def ingest(
             if ingest_table is not target_table:
                 with get_pg_force_execute(conn, logger):
                     dependent_views = get_dependent_views(sql, conn, target_table.schema, target_table.name)
-                    if dependent_views:
-                        logger.info("Dropping dependent views for %s.%s", str(target_table.schema), str(target_table.name))
-                        drop_views(sql, conn, dependent_views)
+                    logger.info("Dropping dependent views for %s.%s", str(target_table.schema), str(target_table.name))
+                    drop_views(sql, conn, dependent_views)
                     target_table.drop(conn)
                     rename_query = sql.SQL('''
                         ALTER TABLE {schema}.{ingest_table}
@@ -566,9 +565,8 @@ def ingest(
                         target_table=sql.Identifier(target_table.name),
                     )
                     conn.execute(sa.text(rename_query.as_string(conn.connection.driver_connection)))
-                    if dependent_views:
-                        logger.info("Recreating dependent views for %s.%s", str(target_table.schema), str(target_table.name))
-                        recreate_views(sql, conn, dependent_views)
+                    logger.info("Recreating dependent views for %s.%s", str(target_table.schema), str(target_table.name))
+                    recreate_views(sql, conn, dependent_views)
 
         if callable(high_watermark_value):
             high_watermark_value = high_watermark_value()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+log_cli=true
+log_level=DEBUG


### PR DESCRIPTION
## what
* added support for tables with dependent views during table ingestions
* view definitions are recreated exactly as-is
* view dependency sql with parsimonious joins
* order agnostic two-phase views recreation: create dummy views with correct structure, replace all views with their actual definitions

## why
* ingestions would fail if a table had dependent views
* now you can safely modify table schemas even when views depend on them

## tests added
* simple dependent views
* multiple views on single table 
* cascading views (views depending on other views)
* simple cyclic views (2 views)
* complex cyclic dependencies (3+ views)
* views with complex expressions including:
   * window functions
   * CASE expressions
   * recursive CTEs
   * multiple CTEs and self-joins
   * nested subqueries
   * cross-view dependencies
* materialized views and their interactions with regular views
* views dependent on wacky identifiers