### PR TITLE
test: add tests for vector types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,14 @@ jobs:
           - "3.11.1"
           - "3.12.0"
         postgresql-version:
-          - "postgres:9.6"
-          - "postgres:10.0"
-          - "postgres:11.0"
-          - "postgres:12.0"
-          - "postgres:13.0"
-          - "postgres:14.0"
-          - "postgres:15.0"
-          - "postgres:16beta2"
+          - "9.6"
+          - "10.0"
+          - "11.0"
+          - "12.0"
+          - "13.0"
+          - "14.0"
+          - "15.0"
+          - "16.0"
         # sqlalchemy 1.4 doesn't support psycopg3
         ci-extras:
           - ci-psycopg2-sqlalchemy1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+ARG VERSION
+
+FROM postgres:$VERSION
+
+ARG VERSION
+
+RUN \
+	if [ -z "${VERSION}" ] || [ ${VERSION%%.*} -ge 14 ]; then \
+		apt update && \
+		apt install -y postgresql-${VERSION%%.*}-pgvector && \
+		rm -rf /var/lib/apt/lists/* \
+	; fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "A collection of Python utility functions for ingesting data into SQLAlchemy-defined PostgreSQL tables, automatically migrating them as needed, and minimising locking"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8.2"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
@@ -26,11 +26,13 @@ dependencies = [
 dev = [
     "psycopg>=3.1.4",
     "psycopg2>=2.9.2",
+    "pgvector>=0.1.8",
     "pytest>=7.2.1",
     # Type checking
     "mypy <1.5",
 ]
 ci = [
+    "pgvector",
     "pytest",
     "pytest-cov",
     "coverage",

--- a/start-services.sh
+++ b/start-services.sh
@@ -2,4 +2,5 @@
 
 set -e
 
-docker run --rm -it --name pg-bulk-ingegst-postgres -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 -d ${1:-postgres}
+docker build . -t postgres-pg-bulk-ingest --build-arg VERSION=${1:-"14.0"}
+docker run --rm -it --name pg-bulk-ingest-postgres -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 -d postgres-pg-bulk-ingest

--- a/stop-services.sh
+++ b/stop-services.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-docker stop pg-bulk-ingegst-postgres
+docker stop pg-bulk-ingest-postgres


### PR DESCRIPTION
This adds a test to ensure pg-bulk-ingest can deal with pgvector types, and changes some of the associated files relating to automating testing so that these tests can be run with multiple versions of postgres and pgvector