### PR TITLE
feat: drop support for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,15 +8,15 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version:
-          - "3.7.1"
-          - "3.8.0"
+          - "3.8.2"
           - "3.9.0"
           - "3.10.0"
-          - "3.11.0"
+          - "3.11.1"
+          - "3.12.0"
         postgresql-version:
           - "postgres:9.6"
           - "postgres:10.0"
@@ -34,16 +34,18 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
-      - uses: "actions/setup-python@v4"
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: '${{ matrix.python-version }}'
+          python-version: ${{ matrix.python-version }}
+          activate-environment: true
       - name: "Run PostgreSQL"
         run: |
           ./start-services.sh ${{ matrix.postgresql-version }}
       - name: "Install package and python dependencies"
         run: |
-          python -m pip install --upgrade pip
-          pip install .[ci,${{ matrix.ci-extras }}]
+          uv pip install --upgrade pip
+          CC=clang uv pip install .[ci,${{ matrix.ci-extras }}]
       - name: "Wait for PostgreSQL"
         run: "timeout 60 bash -c 'until echo > /dev/tcp/127.0.0.1/5432; do sleep 5; done'"
       - name: "Run Type Checking"
@@ -51,5 +53,6 @@ jobs:
           mypy pg_bulk_ingest
       - name: "Test"
         run: |
-          pytest --cov
+          python --version
+          PG_VERSION=${{ matrix.postgresql-version }} pytest --cov
       - uses: codecov/codecov-action@v3

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -6,7 +6,7 @@ title: Compatibility
 
 pg-bulk-ingest aims to be compatible with a wide range of Python and other dependencies:
 
-- Python >= 3.7.1 (tested on 3.7.1, 3.8.0, 3.9.0, 3.10.0, and 3.11.0)
+- Python >= 3.8.2 (tested on 3.8.2, 3.9.0, 3.10.0, 3.11.1, and 3.12.0)
 - psycopg2 >= 2.9.2 and Psycopg 3 >= 3.1.4
 - SQLAlchemy >= 1.4.24 (tested on 1.4.24 and 2.0.0)
 - PostgreSQL >= 9.6 (tested on 9.6, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, and 16 Beta 2)


### PR DESCRIPTION
This:

- Drops support for Python 3.7
- Moves to using uv for installing Python versions rather than the setup-python action
- Adds Python 3.12 to tests in CI

The drop of Python support is because neither GitHub's setup-python action nor uv now support Python 3.7. The move to uv is because it seems to support the install of more Python versions that GitHub setup-python action.