### PR TITLE
fix: doc deployment

### DIFF
--- a/.github/workflows/deploy-docs-to-github-pages.yml
+++ b/.github/workflows/deploy-docs-to-github-pages.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Build with Eleventy
       run: npx eleventy
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This fixes the GitHub pages documentation deployment by bumping the version of actions/upload-pages-artifact to v3 (v2 no longer functions)