### PR TITLE
ci: use token to upload code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,4 +55,6 @@ jobs:
         run: |
           python --version
           PG_VERSION=${{ matrix.postgresql-version }} pytest --cov
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The changes how code coverage is uploaded to Codecov - now using a token.

This is because without using a token frequently hit rate limiting, and this should be much less likely if using our own token.

The token was added as a "repository secret" before this change was raised.