### PR TITLE
fix: upload of docs to GitHub pages (attempt 2)

### DIFF
--- a/.github/workflows/deploy-docs-to-github-pages.yml
+++ b/.github/workflows/deploy-docs-to-github-pages.yml
@@ -33,4 +33,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This is a second attempt at fixing the upload of docs to GitHub pages. This time, by bumping the version of actions/deploy-pages to the most recent - hopefully it can now find the artifact uploaded by actions/upload-pages-artifact