### PR TITLE
feat: re-introduce support for Python 3.7.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - "3.7.7"
           - "3.8.2"
           - "3.9.0"
           - "3.10.0"
@@ -37,6 +38,10 @@ jobs:
       - name: Install uv and set the python version
         uses: astral-sh/setup-uv@v6
         with:
+          # The version of uv itself is pinned, which allows us to install older Python. Suspect
+          # that eventually to install newer Python, will need to have the version of uv specified
+          # in the matrix
+          version: "0.6.17"
           python-version: ${{ matrix.python-version }}
           activate-environment: true
       - name: "Run PostgreSQL"

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -6,7 +6,7 @@ title: Compatibility
 
 pg-bulk-ingest aims to be compatible with a wide range of Python and other dependencies:
 
-- Python >= 3.8.2 (tested on 3.8.2, 3.9.0, 3.10.0, 3.11.1, and 3.12.0)
+- Python >= 3.7.7 (tested on 3.7.7, 3.8.2, 3.9.0, 3.10.0, 3.11.1, and 3.12.0)
 - psycopg2 >= 2.9.2 and Psycopg 3 >= 3.1.4
 - SQLAlchemy >= 1.4.24 (tested on 1.4.24 and 2.0.0)
 - PostgreSQL >= 9.6 (tested on 9.6, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, and 16 Beta 2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "A collection of Python utility functions for ingesting data into SQLAlchemy-defined PostgreSQL tables, automatically migrating them as needed, and minimising locking"
 readme = "README.md"
-requires-python = ">=3.8.2"
+requires-python = ">=3.7.7"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/test_pg_bulk_ingest.py
+++ b/test_pg_bulk_ingest.py
@@ -2,12 +2,12 @@ import uuid
 import io
 import itertools
 import os
+import sys
 from contextlib import contextmanager
 from datetime import date
 
 import pytest
 import sqlalchemy as sa
-from pgvector.sqlalchemy import VECTOR
 
 try:
     # psycopg2
@@ -1567,8 +1567,11 @@ def test_streaming_behaviour_of_to_file_object() -> None:
     assert total_read == 1
 
 
+@pytest.mark.skipif(sys.version_info[:2] < (3,8,0), reason="VECTOR type not available in pgvector.sqlalchemy")
 @pytest.mark.skipif(float(os.environ.get('PG_VERSION', '14.0')) < 14.0, reason="pgvector not available")
 def test_insert_vectors():
+    from pgvector.sqlalchemy import VECTOR
+
     engine = sa.create_engine(f'{engine_type}://postgres@127.0.0.1:5432/', **engine_future)
 
     with engine.connect() as conn:


### PR DESCRIPTION
This re-introduces support for Python 3.7, albeit Python 3.7.7. This is done by pinning to an earlier version of uv, one that still can install this version of Python.