### PR TITLE
ci: run tests on Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
           - "3.10.0"
           - "3.11.1"
           - "3.12.0"
+          - "3.13.0"
         postgresql-version:
           - "9.6"
           - "10.0"
@@ -27,11 +28,58 @@ jobs:
           - "14.0"
           - "15.0"
           - "16.0"
-        # sqlalchemy 1.4 doesn't support psycopg3
+        # SqlAlchemy 1.4 doesn't support psycopg3, psycopg2 < 2.9.10, doesn't support Python 13,
+        # and SqlAlchemy 2 < 2.0.30 doesn't support Python 13
         ci-extras:
           - ci-psycopg2-sqlalchemy1
           - ci-psycopg2-sqlalchemy2
+          - ci-psycopg2-9-10-sqlalchemy1
+          - ci-psycopg2-9-10-sqlalchemy2-0-31
           - ci-psycopg3-sqlalchemy2
+          - ci-psycopg3-sqlalchemy2-0-31
+        exclude:
+          - python-version: "3.7.7"
+            ci-extras: ci-psycopg2-9-10-sqlalchemy1
+          - python-version: "3.7.7"
+            ci-extras: ci-psycopg2-9-10-sqlalchemy2-0-31
+          - python-version: "3.7.7"
+            ci-extras: ci-psycopg3-sqlalchemy2-0-31
+          - python-version: "3.8.2"
+            ci-extras: ci-psycopg2-9-10-sqlalchemy1
+          - python-version: "3.8.2"
+            ci-extras: ci-psycopg2-9-10-sqlalchemy2-0-31
+          - python-version: "3.8.2"
+            ci-extras: ci-psycopg3-sqlalchemy2-0-31
+          - python-version: "3.9.0"
+            ci-extras: ci-psycopg2-9-10-sqlalchemy1
+          - python-version: "3.9.0"
+            ci-extras: ci-psycopg2-9-10-sqlalchemy2-0-31
+          - python-version: "3.9.0"
+            ci-extras: ci-psycopg3-sqlalchemy2-0-31
+          - python-version: "3.10.0"
+            ci-extras: ci-psycopg2-9-10-sqlalchemy1
+          - python-version: "3.10.0"
+            ci-extras: ci-psycopg2-9-10-sqlalchemy2-0-31
+          - python-version: "3.10.0"
+            ci-extras: ci-psycopg3-sqlalchemy2-0-31
+          - python-version: "3.11.0"
+            ci-extras: ci-psycopg2-9-10-sqlalchemy1
+          - python-version: "3.11.0"
+            ci-extras: ci-psycopg2-9-10-sqlalchemy2-0-31
+          - python-version: "3.11.0"
+            ci-extras: ci-psycopg3-sqlalchemy2-0-31
+          - python-version: "3.12.0"
+            ci-extras: ci-psycopg2-9-10-sqlalchemy1
+          - python-version: "3.12.0"
+            ci-extras: ci-psycopg2-9-10-sqlalchemy2-0-31
+          - python-version: "3.12.0"
+            ci-extras: ci-psycopg3-sqlalchemy2-0-31
+          - python-version: "3.13.0"
+            ci-extras: ci-psycopg2-sqlalchemy1
+          - python-version: "3.13.0"
+            ci-extras: ci-psycopg2-sqlalchemy2
+          - python-version: "3.13.0"
+            ci-extras: ci-psycopg3-sqlalchemy2
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -6,9 +6,9 @@ title: Compatibility
 
 pg-bulk-ingest aims to be compatible with a wide range of Python and other dependencies:
 
-- Python >= 3.7.7 (tested on 3.7.7, 3.8.2, 3.9.0, 3.10.0, 3.11.1, and 3.12.0)
-- psycopg2 >= 2.9.2 and Psycopg 3 >= 3.1.4
-- SQLAlchemy >= 1.4.24 (tested on 1.4.24 and 2.0.0)
+- Python >= 3.7.7 (tested on 3.7.7, 3.8.2, 3.9.0, 3.10.0, 3.11.1, 3.12.0, and 3.13.0)
+- psycopg2 >= 2.9.2 (tested on 2.9.2 with Python < 3.13.0, and 2.9.10 with Python 3.13.0) and Psycopg 3 >= 3.1.4 (tested on 3.1.4)
+- SQLAlchemy >= 1.4.24 (tested on 1.4.24 with all Python versions, 2.0.0 with Python < 3.13.0, and 2.0.31 with Python 3.13.0)
 - PostgreSQL >= 9.6 (tested on 9.6, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, and 16 Beta 2)
 
 Note that SQLAlchemy < 2 does not support Psycopg 3, and for SQLAlchemy < 2 `future=True` must be passed to its `create_engine` function.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,24 @@ ci-psycopg2-sqlalchemy2 = [
     "sqlalchemy==2.0.0",
     "to-file-like-obj==0.0.5",
 ]
+ci-psycopg2-9-10-sqlalchemy1 = [
+    "psycopg2==2.9.10",
+    "sqlalchemy==1.4.24",
+    "to-file-like-obj==0.0.5",
+]
 ci-psycopg3-sqlalchemy2 = [
     "psycopg==3.1.4",
     "sqlalchemy==2.0.0",
+    "to-file-like-obj==0.0.5",
+]
+ci-psycopg2-9-10-sqlalchemy2-0-31 = [
+    "psycopg2==2.9.10",
+    "sqlalchemy==2.0.31",
+    "to-file-like-obj==0.0.5",
+]
+ci-psycopg3-sqlalchemy2-0-31 = [
+    "psycopg==3.1.4",
+    "sqlalchemy==2.0.31",
     "to-file-like-obj==0.0.5",
 ]
 


### PR DESCRIPTION
This makes tests run on Python 3.13.

psycopg2 doesn't support Python 3.13.0 until 2.9.10, so tests for Python 3.13.0 are not run for earlier psycopg2

Similarly, SQLAlchemy 2 doesn't support Python 3.13.0 until 2.0.31.