### PR TITLE
fix: only commit once per batch, even when recreating views

### DIFF
--- a/pg_bulk_ingest/__init__.py
+++ b/pg_bulk_ingest/__init__.py
@@ -243,7 +243,6 @@ def ingest(
                     null_columns=sql.SQL(view['null_typed_columns'])
                 )
                 conn.execute(sa.text(query.as_string(conn.connection.driver_connection)))
-                conn.commit()
 
         for view in views:
             if view["is_materialized"]:
@@ -252,7 +251,6 @@ def ingest(
             else:
                 logger.info("Recreating original view %s", view['fully_qualified_name'])
                 conn.execute(sa.text(view['definition']))
-            conn.commit()
 
     def create_first_batch_ingest_table_if_necessary(sql: typing.Any, conn: typing.Any, live_table: sa.Table, target_table: sa.Table) -> sa.Table:
         must_create_ingest_table = False

--- a/start-services.sh
+++ b/start-services.sh
@@ -3,4 +3,4 @@
 set -e
 
 docker build . -t postgres-pg-bulk-ingest --build-arg VERSION=${1:-"14.0"}
-docker run --rm -it --name pg-bulk-ingest-postgres -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 -d postgres-pg-bulk-ingest
+docker run --rm -it --name pg-bulk-ingest-postgres -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 -d postgres-pg-bulk-ingest -N 10000


### PR DESCRIPTION
This removes commits per view when recreating views, and restoring a commit once per batch approach, so changes are only seen by other clients at the end of a batch and not before.

This does mean the exclusive locks on all the views are accumulated, but I think that is the least-bad option, because otherwise views will be visible in an inconsistent state (/ without any data in some cases), albeit briefly.