### PR TITLE
fix: improve robustness of chains of materialized views

### DIFF
--- a/pg_bulk_ingest/__init__.py
+++ b/pg_bulk_ingest/__init__.py
@@ -154,8 +154,17 @@ def ingest(
                     and not view_depend.refobjid = ANY(view_deps.path)
             )
 
-            -- We now get all the information in order to drop and re-create the views. Note that we don't care
-            -- about any sort of ordering because:
+            -- We now get all the information in order to drop and re-create the views.
+            -- 
+            -- The ordering is important only for materialized views so they are re-created in
+            -- dependency order. The correct order is the order that the materialized views are
+            -- discovered by the recursive CTE, so technically the ORDER BY clause is redundant.
+            -- But this I suspect is an implementation detail of current versions of PostgreSQL,
+            -- and not guarenteed, so an explicit ORDER BY clause is added to make sure we return
+            -- each level of the graph before the next.
+            --
+            -- For completeness, correct handling of non-materialized views don't depend on the
+            -- ORDER BY because:
             -- 1. We will drop using DROP IF EXISTS ... CASCADE
             -- 2. We will create by first creating "dummy" views with the right columns and datatypes on all the
             --    the views, and then replace them all with the correct definitions. This is the only way to
@@ -186,6 +195,8 @@ def ingest(
                 pg_attribute.attnum > 0 AND NOT pg_attribute.attisdropped
             GROUP BY
                 view_deps.refobjid, c.relkind
+            ORDER BY
+                min(array_length(view_deps.path, 1))
         ''').format(
             schema=sql.Literal(schema),
             table=sql.Literal(table)


### PR DESCRIPTION
This adds an ORDER BY clause to the view discovery query to make sure views are returned in order of their dependency.

This is for materialised views, so they are created, and so refreshed, in order.