### PR TITLE
fix: preservation of SELECT on views by view owner

### DIFF
--- a/pg_bulk_ingest/__init__.py
+++ b/pg_bulk_ingest/__init__.py
@@ -664,7 +664,7 @@ SELECT
     c.relkind = 'm' as is_materialized,
     (
         SELECT string_agg(grantee::regrole::text, ',')
-        FROM aclexplode(c.relacl)
+        FROM aclexplode(coalesce(c.relacl, acldefault('r', c.relowner)))
         WHERE privilege_type = 'SELECT'
     ) AS quoted_grantees
 FROM (


### PR DESCRIPTION
This adds in the use of `acldefault` when finding existing SELECT privileges on a view. This is so that SELECT privileges are not lost when views owned by users other than doing the ingest are recreated.

Suspect this is still another change after this - to make sure ownership of recreated views are preserved.