### PR TITLE
refactor: test multiple engine types/dialects each test run via parameterisation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,58 +28,9 @@ jobs:
           - "14.0"
           - "15.0"
           - "16.0"
-        # SqlAlchemy 1.4 doesn't support psycopg3, psycopg2 < 2.9.10, doesn't support Python 13,
-        # and SqlAlchemy 2 < 2.0.30 doesn't support Python 13
         ci-extras:
-          - ci-psycopg2-sqlalchemy1
-          - ci-psycopg2-sqlalchemy2
-          - ci-psycopg2-9-10-sqlalchemy1
-          - ci-psycopg2-9-10-sqlalchemy2-0-31
-          - ci-psycopg3-sqlalchemy2
-          - ci-psycopg3-sqlalchemy2-0-31
-        exclude:
-          - python-version: "3.7.7"
-            ci-extras: ci-psycopg2-9-10-sqlalchemy1
-          - python-version: "3.7.7"
-            ci-extras: ci-psycopg2-9-10-sqlalchemy2-0-31
-          - python-version: "3.7.7"
-            ci-extras: ci-psycopg3-sqlalchemy2-0-31
-          - python-version: "3.8.2"
-            ci-extras: ci-psycopg2-9-10-sqlalchemy1
-          - python-version: "3.8.2"
-            ci-extras: ci-psycopg2-9-10-sqlalchemy2-0-31
-          - python-version: "3.8.2"
-            ci-extras: ci-psycopg3-sqlalchemy2-0-31
-          - python-version: "3.9.0"
-            ci-extras: ci-psycopg2-9-10-sqlalchemy1
-          - python-version: "3.9.0"
-            ci-extras: ci-psycopg2-9-10-sqlalchemy2-0-31
-          - python-version: "3.9.0"
-            ci-extras: ci-psycopg3-sqlalchemy2-0-31
-          - python-version: "3.10.0"
-            ci-extras: ci-psycopg2-9-10-sqlalchemy1
-          - python-version: "3.10.0"
-            ci-extras: ci-psycopg2-9-10-sqlalchemy2-0-31
-          - python-version: "3.10.0"
-            ci-extras: ci-psycopg3-sqlalchemy2-0-31
-          - python-version: "3.11.0"
-            ci-extras: ci-psycopg2-9-10-sqlalchemy1
-          - python-version: "3.11.0"
-            ci-extras: ci-psycopg2-9-10-sqlalchemy2-0-31
-          - python-version: "3.11.0"
-            ci-extras: ci-psycopg3-sqlalchemy2-0-31
-          - python-version: "3.12.0"
-            ci-extras: ci-psycopg2-9-10-sqlalchemy1
-          - python-version: "3.12.0"
-            ci-extras: ci-psycopg2-9-10-sqlalchemy2-0-31
-          - python-version: "3.12.0"
-            ci-extras: ci-psycopg3-sqlalchemy2-0-31
-          - python-version: "3.13.0"
-            ci-extras: ci-psycopg2-sqlalchemy1
-          - python-version: "3.13.0"
-            ci-extras: ci-psycopg2-sqlalchemy2
-          - python-version: "3.13.0"
-            ci-extras: ci-psycopg3-sqlalchemy2
+          - ci-sqlalchemy1
+          - ci-sqlalchemy2
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
@@ -98,7 +49,7 @@ jobs:
       - name: "Install package and python dependencies"
         run: |
           uv pip install --upgrade pip
-          CC=clang uv pip install .[ci,${{ matrix.ci-extras }}]
+          CC=clang uv pip install .[dev,ci,${{ matrix.ci-extras }}]
       - name: "Wait for PostgreSQL"
         run: "timeout 60 bash -c 'until echo > /dev/tcp/127.0.0.1/5432; do sleep 5; done'"
       - name: "Run Type Checking"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,50 +24,30 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "psycopg>=3.1.4",
-    "psycopg2>=2.9.2",
-    "pgvector>=0.1.8",
-    "pytest>=7.2.1",
-    # Type checking
-    "mypy <1.5",
-]
-ci = [
-    "pgvector",
+    # To run tests
     "pytest",
     "pytest-cov",
     "coverage",
-    # Type checking
-    "mypy <1.5",
+    # Used directly in tests
+    "psycopg>=3.1.4",
+    "psycopg2>=2.9.2",
+    "pgvector>=0.1.8",
+    # To run type checking
+    "mypy<1.5",
 ]
-ci-psycopg2-sqlalchemy1 = [
-    "psycopg2==2.9.2",
-    "sqlalchemy==1.4.24",
+ci = [
     "to-file-like-obj==0.0.5",
-]
-ci-psycopg2-sqlalchemy2 = [
-    "psycopg2==2.9.2",
-    "sqlalchemy==2.0.0",
-    "to-file-like-obj==0.0.5",
-]
-ci-psycopg2-9-10-sqlalchemy1 = [
-    "psycopg2==2.9.10",
-    "sqlalchemy==1.4.24",
-    "to-file-like-obj==0.0.5",
-]
-ci-psycopg3-sqlalchemy2 = [
+    "pg-force-execute==0.0.10",
+    "psycopg2==2.9.2;python_version<'3.13'",
+    "psycopg2==2.9.10;python_version>='3.13'",
     "psycopg==3.1.4",
-    "sqlalchemy==2.0.0",
-    "to-file-like-obj==0.0.5",
 ]
-ci-psycopg2-9-10-sqlalchemy2-0-31 = [
-    "psycopg2==2.9.10",
-    "sqlalchemy==2.0.31",
-    "to-file-like-obj==0.0.5",
+ci-sqlalchemy1 = [
+    "sqlalchemy==1.4.24",
 ]
-ci-psycopg3-sqlalchemy2-0-31 = [
-    "psycopg==3.1.4",
-    "sqlalchemy==2.0.31",
-    "to-file-like-obj==0.0.5",
+ci-sqlalchemy2 = [
+    "sqlalchemy==2.0.0;python_version<'3.13'",
+    "sqlalchemy==2.0.31;python_version>='3.13'",
 ]
 
 [project.urls]


### PR DESCRIPTION
This refactors tests, including how they are run in ci, and specifically:

- The engine type (aka dialect) is chosen by parameterisation, rather than what happens to be installed
- The versions installed are wherever possible enshrined in pyproject.toml via constraints on the python_version

This is done primarily to make it easier to test with more dialects (e.g. with an ADBC dialect to ingest arrow table more efficiently), but it also makes the ci config more understandable without the many excludes.